### PR TITLE
[feat/EATBOOK-95] router 및 zustand 코드 추가

### DIFF
--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+// project
+import useSideBarStore from '../store/store.tsx';
+
+// css
+import { Sidebar } from 'flowbite-react';
+import { FaHouse, FaUser, FaChartSimple, FaBars } from 'react-icons/fa6';
+
+// sidebar custom
+
+export function SideBar(): React.JSX.Element {
+  const toggle = useSideBarStore((state) => state.toggleIsOpened);
+
+  // Sidebar Custom
+  const customTheme = {
+    root: {
+      base: 'bg-white h-full', // Sidebar 전체 배경색과 텍스트 색상
+      inner: 'p-4', // Sidebar 내부 패딩
+    },
+
+
+  };
+
+  return (
+    <Sidebar className='ease-in-out duration-500 shadow-2xl drop-shadow-2xl' theme={customTheme}>
+      <div className="">
+        <button
+          onClick={toggle}
+          className='relative flex items-center'
+        >
+          <FaBars size={18} className="fill-button-text mx-auto" />
+        </button>
+      </div>
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item as={Link} to='/' icon={FaHouse}>
+            HOME
+          </Sidebar.Item>
+          <Sidebar.Item as={Link} to='/members' icon={FaUser}>
+            MEMBERS</Sidebar.Item>
+          <Sidebar.Item as={Link} to='/dashboard' icon={FaChartSimple}>
+            DASHBOARD</Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+    </Sidebar>
+  );
+}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,14 +1,15 @@
 import React from "react";
+import { Link } from 'react-router-dom';
 
 export function Header(): React.JSX.Element {
     return (
         <div className="w-full h-[45px] px-3.5 py-3.5 bg-[#fffaeb] flex justify-between items-center">
-            <div className="h-[45px] justify-start items-center flex">
+            <Link to='/' className="h-[45px] justify-start items-center flex">
                 <div
                     className="h-[60px] text-center text-[#633200] text-[20px] font-normal font-jejudoldam leading-[60px]">BookKeeper
                 </div>
                 <img className="w-[40px] h-[35px]" src="/src/assets/face-total.png"/>
-            </div>
+            </Link>
             <div
                 className="w-[70px] h-[35px] px-px py-[7px] bg-[#dbb185] rounded-[10px] shadow justify-center items-center gap-2.5 flex">
                 <div className="text-center text-white text-[15px] font-semibold leading-[34.50px]">로그아웃</div>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -8,7 +8,7 @@ export function Header(): React.JSX.Element {
                 <div
                     className="h-[60px] text-center text-[#633200] text-[20px] font-normal font-jejudoldam leading-[60px]">BookKeeper
                 </div>
-                <img className="w-[40px] h-[35px]" src="/src/assets/face-total.png"/>
+                <img alt="fox-logo" className="w-[40px] h-[35px]" src="/src/assets/face-total.png"/>
             </Link>
             <div
                 className="w-[70px] h-[35px] px-px py-[7px] bg-[#dbb185] rounded-[10px] shadow justify-center items-center gap-2.5 flex">

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,0 +1,41 @@
+import { Outlet } from 'react-router-dom';
+
+// project
+import { SideBar } from '../components/SideBar.tsx';
+import useSideBarStore from '../store/store.tsx';
+
+const MainLayout = (): React.JSX.Element => {
+  const isOpened = useSideBarStore((state) => state.isOpened);
+  const toggle = useSideBarStore((state) => state.toggleIsOpened);
+
+  // handler
+  const handleOutsideClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (isOpened) {
+      // 클릭한 요소가 사이드바가 아닐 경우에만 toggle 실행
+      const sidebarElement = document.querySelector('aside');
+      if (sidebarElement && !sidebarElement.contains(event.target as Node)) {
+        toggle();
+      }
+    }
+  };
+
+  return (
+    <div className="h-full flex relative" onClick={handleOutsideClick}>
+      {/* SideBar */}
+      <aside
+        className={`fixed h-full z-10 transform transition-transform duration-300 ${
+          isOpened ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <SideBar />
+      </aside>
+
+      {/* contents */}
+      <main className="w-full">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
 import './index.css'
+import { RouterProvider } from 'react-router-dom';
+import router from './routes/Routes.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
-)
+);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,76 +1,87 @@
-import React from 'react';
+import React, { useState } from 'react';
+
 
 // project
-import {Header} from "../components/header";
-import SearchBar from "../components/SearchBar.tsx";
-import FormButton from "../components/FormButton.tsx";
-import SimpleBookCard from "../components/SimpleBookCard.tsx";
+import SearchBar from '../components/SearchBar.tsx';
+import FormButton from '../components/FormButton.tsx';
+import SimpleBookCard from '../components/SimpleBookCard.tsx';
+import { CategoryType } from '../store/types.tsx';
+import AddBook from './form/AddBook.tsx';
 
 // css
-import {Button} from "flowbite-react";
-import {FaBars} from "react-icons/fa6";
+import { Button, Pagination } from 'flowbite-react';
+import { FaBars } from 'react-icons/fa6';
+import useSideBarStore from '../store/store.tsx';
+import { Link } from 'react-router-dom';
 
 function Home(): React.JSX.Element {
-    return (
-        <>
-            {/* logo & search section */}
-            <section className="flex flex-col w-full bg-main h-72 justify-center items-center gap-2">
-                <div className="absolute top-5 left-8 flex flex-row gap-5">
-                    <button><FaBars size={18} className="fill-button-text" /></button>
-                    <button className="text-button-text font-medium text-sm">로그아웃</button>
-                </div>
-                <img src="src/assets/logo.png"
-                     className="w-1/3 mt-10"
-                />
-                <div className="w-1/2">
-                    <SearchBar/>
-                </div>
-            </section>
+  const toggle = useSideBarStore((state) => state.toggleIsOpened);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isModalOpened, setModalOpened] = useState(false);
+  const categories: CategoryType[] = Object.values(CategoryType);
 
-            {/* book list container */}
-            <div className="container mx-auto mt-10 max-w-5xl pb-20">
-                <div className="flex flex-col w-full divide-y">
-                    <div className="flex justify-between mb-2">
-                        <span className="text-xl font-bold">서적목록</span>
-                        <FormButton label="새 작품 만들기"/>
-                    </div>
-                    <div className="flex flex-row gap-2 py-2">
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>전체</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>고전소설</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>판타지</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>무협</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>로맨스</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>코미디</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>라이트노벨</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>추리</Button>
-                        <Button pill size="xs" color="gray"
-                                className={`text-line focus:ring-0`}>미스테리</Button>
-                    </div>
-                </div>
-                <div className="grid grid-cols-5 mx-auto mt-5 justify-items-center gap-x-1 gap-y-10">
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                    <SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" />
-                </div>
+  const onPageChange = (page: number) => setCurrentPage(page);
+  const openModal = () => setModalOpened(true);
+  const closeModal = () => setModalOpened(false);
 
-            </div>
-        </>
-    )
+  return (
+    <>
+      {/* logo & search section */}
+      <section className="flex flex-col w-full bg-main h-72 justify-center items-center gap-2">
+        <div className="absolute top-5 left-8 flex flex-row gap-5">
+          <button onClick={toggle}
+          ><FaBars size={18} className="fill-button-text" /></button>
+          <button className="text-button-text font-medium text-sm">로그아웃</button>
+        </div>
+        <Link to="/" className="w-1/3 mt-10">
+          <img src="src/assets/logo.png" />
+        </Link>
+        <div className="w-1/2">
+          <SearchBar />
+        </div>
+      </section>
+
+      {/* book list container */}
+      <div className="container mx-auto mt-10 max-w-5xl pb-20">
+        <div className="flex flex-col w-full divide-y">
+          <div className="flex justify-between mb-2">
+            <span className="text-xl font-bold">서적목록</span>
+            <button onClick={openModal}><FormButton label="새 작품 만들기" /></button>
+          </div>
+          <div className="flex flex-row gap-2 py-2">
+            {
+              categories.map((category: CategoryType, index) => (
+                <Button key={index} pill size="xs" color="gray"
+                        className={`text-line focus:ring-0`}>{category}</Button>
+              ))
+            }
+          </div>
+        </div>
+        <div className="grid grid-cols-5 mx-auto mt-5 justify-items-center gap-x-1 gap-y-10">
+          <Link to='/book'><SimpleBookCard title="데미안" author="헤르만 헤세" category="고전소설" coverImageUrl="src/assets/book-cover.png" /></Link>
+        </div>
+
+        {/* 페이지 번호 */}
+        <div className="mt-12 flex justify-center">
+          <Pagination
+            currentPage={currentPage}
+            onPageChange={onPageChange}
+            totalPages={20}
+            previousLabel=""
+            nextLabel=""
+            showIcons
+          />
+        </div>
+      </div>
+
+      {/* open modal */}
+      {isModalOpened && (
+        <div>
+          <AddBook isOpened={isModalOpened} onClose={closeModal} />
+        </div>
+      )}
+    </>
+  );
 }
 
 export default Home;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -34,7 +34,7 @@ function Home(): React.JSX.Element {
           <button className="text-button-text font-medium text-sm">로그아웃</button>
         </div>
         <Link to="/" className="w-1/3 mt-10">
-          <img src="src/assets/logo.png" />
+          <img alt='logo' src="src/assets/logo.png" />
         </Link>
         <div className="w-1/2">
           <SearchBar />

--- a/src/pages/book/BookDetail.tsx
+++ b/src/pages/book/BookDetail.tsx
@@ -5,9 +5,11 @@ import { Header } from "../../components/header";
 import FormButton from "../../components/FormButton.tsx";
 import EpisodeListItem from "../../components/EpisodeListItem.tsx";
 import CommentItem from "../../components/CommentItem.tsx";
+import { BookDetailTabType } from '../../store/types.tsx';
+import PopUp from '../form/PopUp.tsx';
 
 // css
-import { FaPen, FaRegTrashAlt, FaHeart, FaTrashAlt } from "react-icons/fa";
+import { FaPen, FaHeart, FaTrashAlt } from "react-icons/fa";
 
 interface Chapter {
   episode: number;
@@ -20,12 +22,7 @@ interface BookDetailProps {
   author: string;
   summary: string;
   like: number;
-  chapterList: Chapter[];
-}
-
-enum TabType {
-  Episodes = "episodes",
-  Comments = "comments",
+  chapterList?: Chapter[];
 }
 
 function BookDetail({
@@ -36,7 +33,9 @@ function BookDetail({
   like,
   chapterList,
 }: BookDetailProps): React.JSX.Element {
-  const [activeTab, setActiveTab] = useState<TabType>(TabType.Episodes);
+  const [activeTab, setActiveTab] = useState<BookDetailTabType>(BookDetailTabType.Episodes);
+  const [popWarning, setPopWarning] = useState<boolean>(false);
+
 
   return (
     <>
@@ -61,11 +60,17 @@ function BookDetail({
                 id="form-button"
                 className="flex flex-row gap-5 px-2 items-center"
               >
-                <FormButton
+                <button><FormButton
                   label="수정"
                   icon={<FaPen size={13} className="fill-button-text" />}
-                />
-                <FaTrashAlt size={25} className="fill-red-500" />
+                /></button>
+                <button
+                  onClick={() => setPopWarning(true)}
+                ><FaTrashAlt size={25} className="fill-red-500" />
+                </button>
+                {popWarning && (
+                  <PopUp isOpened={popWarning} onClose={() => setPopWarning(false)} />
+                )}
               </div>
             </div>
             <span className="text-sm text-start">{summary}</span>
@@ -81,27 +86,27 @@ function BookDetail({
           {/* 회차-댓글 전환 버튼 */}
           <div className="flex flex-row py-3 text-lg">
             <button
-              className={`w-full ${activeTab === TabType.Episodes ? "underline underline-offset-2" : ""}`}
-              onClick={() => setActiveTab(TabType.Episodes)}
+              className={`w-full ${activeTab === BookDetailTabType.Episodes ? "underline underline-offset-2" : ""}`}
+              onClick={() => setActiveTab(BookDetailTabType.Episodes)}
             >
               회차 정보
             </button>
             <button
-              className={`w-full bg-opacity-0 ${activeTab === TabType.Comments ? "underline underline-offset-2" : ""}`}
-              onClick={() => setActiveTab(TabType.Comments)}
+              className={`w-full bg-opacity-0 ${activeTab === BookDetailTabType.Comments ? "underline underline-offset-2" : ""}`}
+              onClick={() => setActiveTab(BookDetailTabType.Comments)}
             >
               댓글
             </button>
           </div>
           <div id="tap-content" className="p-2">
-            {activeTab === TabType.Episodes &&
+            {activeTab === BookDetailTabType.Episodes && chapterList && chapterList.length > 0 &&
               chapterList.map((ch, index) => (
                 <EpisodeListItem
                   chapterNum={index + 1}
                   episodeTitle={ch.subtitle}
                 />
               ))}
-            {activeTab === TabType.Comments && (
+            {activeTab === BookDetailTabType.Comments && (
               <CommentItem
                 chapter={1}
                 nickname="크리스탈"

--- a/src/pages/book/BookDetail.tsx
+++ b/src/pages/book/BookDetail.tsx
@@ -44,6 +44,7 @@ function BookDetail({
         {/* 도서 기본 정보 */}
         <div className="flex flex-row gap-5 p-1">
           <img
+            alt='book-cover-image'
             src={coverImageUrl}
             className="w-48 h-64 rounded-normal-radius shadow-md"
           />

--- a/src/pages/form/AddBook.tsx
+++ b/src/pages/form/AddBook.tsx
@@ -1,40 +1,46 @@
-import React from "react";
-import { AiOutlineUpload, AiOutlinePlus } from "react-icons/ai";
-import { useForm } from "react-hook-form";
+import React from 'react';
+import { AiOutlineUpload, AiOutlinePlus } from 'react-icons/ai';
 
 // project
-import MainButton from "../../components/MainButton";
-import InputBox from "../../components/InputBox";
-import SelectChip from "../../components/SelectChip.tsx";
+import MainButton from '../../components/MainButton';
+import InputBox from '../../components/InputBox';
+import SelectChip from '../../components/SelectChip.tsx';
 
 type AddBookProps = {
-  isOpend: boolean;
+  isOpened: boolean;
+  onClose: () => void;
 };
 
-function AddBook({ isOpend = true }: AddBookProps): React.JSX.Element | null {
+function AddBook({ isOpened, onClose }: AddBookProps): React.JSX.Element | null {
   // 카테고리 추후 store에 저장
   const categories: string[] = [
-    "고전소설",
-    "판타지",
-    "무협",
-    "로맨스",
-    "코미디",
-    "라이트노벨",
-    "추리",
-    "미스테리",
+    '고전소설',
+    '판타지',
+    '무협',
+    '로맨스',
+    '코미디',
+    '라이트노벨',
+    '추리',
+    '미스테리',
   ];
 
   return (
     <>
-      {isOpend && (
-        <div className="fixed inset-0 bg-black bg-opacity-20 flex justify-center items-center">
-          <div className="flex flex-col gap-5 bg-white w-[800px] p-6 rounded-md shadow-lg">
+      {isOpened && (
+        <div className="fixed inset-0 bg-black bg-opacity-20 flex justify-center items-center"
+        >
+          <div className="flex flex-col gap-5 bg-white w-[900px] p-6 rounded-md shadow-lg">
             {/* 저장 버튼 */}
-            <MainButton className="w-14 self-end" label="저장" />
+            <div className="fixed flex self-end gap-3">
+              <button><MainButton className="w-14" label="저장" /></button>
+              <button
+                onClick={onClose}
+              ><MainButton className="w-14 bg-gray-400" label="닫기" /></button>
+            </div>
 
             {/* 표지 등록 */}
-            <div className="flex flex-row">
-              <h2 className="w-[250px] ml-3 text-lg font-bold">표지 등록</h2>
+            <div className="flex flex-row pt-8">
+              <h2 className="w-[250px] ml-10 text-lg font-bold">표지 등록</h2>
               <span className="flex justify-center items-center rounded-normal-radius w-28 h-32 bg-background">
                 <AiOutlineUpload size={40} />
               </span>
@@ -42,7 +48,7 @@ function AddBook({ isOpend = true }: AddBookProps): React.JSX.Element | null {
 
             {/* 도서 정보 */}
             <div className="flex flex-row">
-              <h2 className="w-[250px] ml-3 text-lg font-bold">도서 정보</h2>
+              <h2 className="w-[250px] ml-10 text-lg font-bold">도서 정보</h2>
               <div className="flex flex-col gap-2.5 w-96">
                 <InputBox label="책 제목" />
                 <div className="flex items-end">
@@ -67,7 +73,7 @@ function AddBook({ isOpend = true }: AddBookProps): React.JSX.Element | null {
 
             {/* 카테고리 */}
             <div className="flex flex-row pb-3">
-              <h2 className="w-[250px] ml-3 text-lg font-bold">카테고리</h2>
+              <h2 className="w-[250px] ml-10 text-lg font-bold">카테고리</h2>
               <div className="flex flex-wrap w-96 gap-3">
                 {categories.map((category) => (
                   <SelectChip

--- a/src/pages/form/PopUp.tsx
+++ b/src/pages/form/PopUp.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+// css
+import { HiOutlineExclamationCircle } from 'react-icons/hi';
+import { Modal, Button } from 'flowbite-react';
+
+interface PopUpProps {
+  isOpened: boolean;
+  onClose: () => void;
+}
+
+function PopUp({ isOpened, onClose }: PopUpProps): React.JSX.Element | null {
+
+  return (
+    <>
+      {isOpened && (
+        <Modal popup show={isOpened} size="md" onClose={onClose}>
+          <Modal.Header />
+          <Modal.Body>
+            <div className="text-center">
+              <HiOutlineExclamationCircle className="mx-auto mb-4 h-14 w-14 text-gray-400" />
+              <h3 className="mb-5 text-lg font-normal text-gray-500">
+                정말 도서를 지우시겠습니까?
+              </h3>
+              <div className="flex justify-center gap-4">
+                <Button color="failure" onClick={onClose}>
+                  삭제
+                </Button>
+                <Button color="gray" onClick={onClose}>
+                  취소
+                </Button>
+              </div>
+            </div>
+          </Modal.Body>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export default PopUp;

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,0 +1,35 @@
+import { createBrowserRouter } from 'react-router-dom';
+
+// project
+import MainLayout from '../layout/MainLayout.tsx';
+import Home from '../pages/Home.tsx';
+import DashBoard from '../pages/DashBoard.tsx';
+import ManageMembers from '../pages/ManageMembers.tsx';
+import BookDetail from '../pages/book/BookDetail.tsx';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <MainLayout />,
+    children: [
+      {
+        path: '/',
+        element: <Home />
+      },
+      {
+        path: 'members/',
+        element: <ManageMembers />
+      },
+      {
+        path: 'dashboard/',
+        element: <DashBoard />
+      },
+      {
+        path: '/book',
+        element: <BookDetail title="데미안" coverImageUrl='/src/assets/book-cover.png' author='헤르만헤서' summary='줄거리~~' like={617} />
+      }
+    ]
+  }
+])
+
+export default router;

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+interface SideBarState {
+  isOpened: boolean;
+  toggleIsOpened: () => void;
+}
+
+const useSideBarStore = create<SideBarState>((set) => ({
+  isOpened: false,
+  toggleIsOpened: () => {
+    set((state) => ({
+      isOpened: !state.isOpened,
+    }))
+  }
+}))
+
+export default useSideBarStore;

--- a/src/store/types.tsx
+++ b/src/store/types.tsx
@@ -1,0 +1,29 @@
+export enum CategoryType {
+  All = "전체",
+  ClassicNovel = "고전소설",
+  Fantasy = "판타지",
+  Romance = "로맨스",
+  FairyTale = "동화",
+}
+
+export enum DisplayType {
+  View = "vies",
+  Like = "like",
+  Comment = "comment",
+  Bookmark = "bookmark"
+}
+
+export enum SortType {
+  Latest = "latest",
+  Alphabetical = "alphabetical"
+}
+
+export enum RoleType {
+  Member = "member",
+  Admin = "admin",
+}
+
+export enum BookDetailTabType {
+  Episodes = "episodes",
+  Comments = "comments",
+}


### PR DESCRIPTION
<!-- 제목 : 이슈명과 동일하게 작성 -->
# router 및 zustand 코드 추가

## 작업사항
<!-- 상세 설명 관련이미지 첨부 -->
- react-router-dom을 이용한 router 코드 작성
- zustand를 이용한 상태관리 코드를 통해 SideBar 상태관리 코드 작성
- (참고) popup창 용 페이지 추가

## 관련 이슈
<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->
- form 제출 후 Redirect를 수행하는 라우팅 코드는 api 코드에 붙을 예정입니다.
- (참고) popup창 띄우면 백그라운드가 까매지는 이슈 해결중입니다.

## 참고사항
- api 코드가 붙으면 BookDetail props가 없어질 예정입니다. 이러면 Routes.tsx가 좀 더 깔끔해질 것 같아요
- 사실 popup창 관련 코드는 이번 PR 주제랑 어긋나는 부분이라 편하게 봐주셔도 될 것 같습니다
- ❓주석을 간단히는 적고 있는데 좀 짧은편이라서, 주석을 좀 더 자세히 적어두는게 보시기 더 편하실까요?? 릴리 의견이 궁금합니다!